### PR TITLE
fix: do not generate token when using datastore emulator

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -173,7 +173,10 @@ export class Auth {
     return `${this.host}/v1/projects/${this.init.project_id}`;
   }
 
-  async setToken(): Promise<OAuth2Token> {
+  async setToken(): Promise<OAuth2Token | undefined> {
+    if (this.init.datastore_host) {
+      return;
+    }
     if (this.#tokenPromise) {
       return this.#tokenPromise;
     }

--- a/util.ts
+++ b/util.ts
@@ -42,12 +42,17 @@ export function assert(
   }
 }
 
-export function getRequestHeaders(token: OAuth2Token): Headers {
-  return new Headers({
+export function getRequestHeaders(token: OAuth2Token | undefined): Headers {
+  const headers = new Headers({
     "accept": "application/json",
-    "authorization": token.toString(),
     "content-type": "application/json",
   });
+
+  if (token) {
+    headers.set("authorization", token.toString());
+  }
+
+  return headers;
 }
 
 function hasToEntity<T>(value: T): value is T & { [toEntity](): Entity } {


### PR DESCRIPTION
I missed this in #3, as there is no auth with the emulator